### PR TITLE
remove function parameter dangling comma for atom linter which hates es8

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -125,7 +125,7 @@ function postprocess (messages, filename) {
           column: start.column,
           endLine: end.line,
           endColumn: end.column,
-        },
+        }
       );
     })
     .filter(m => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-coffeescript",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Transpiles coffee files (.coffee, .cjsx) and runs through eslint. Reports errors with original line numbers.",
   "main": "lib/index.js",
   "keywords": [


### PR DESCRIPTION
…ch hates es8

good idea? not sure why my colleages' atom linter isn't supporting es8 but it's causing a headache